### PR TITLE
Whitelist Symbol for YAML.safe_load

### DIFF
--- a/lib/ravioli/builder.rb
+++ b/lib/ravioli/builder.rb
@@ -255,7 +255,7 @@ module Ravioli
     def parse_yaml_config_file(path)
       contents = File.read(path)
       erb = ERB.new(contents).tap { |renderer| renderer.filename = path.to_s }
-      YAML.safe_load(erb.result, aliases: true)
+      YAML.safe_load(erb.result, [Symbol], aliases: true)
     end
 
     def path_to_config_file_path(path, extnames: EXTNAMES, quiet: false)


### PR DESCRIPTION
Sidekiq uses symbols for keys in sidekiq.yml

Ravioli fails to load a yml file with symbols for keys as is need for use with sidekiq.yml

sidekiq.yml:
```
---
:concurrency: 1
:queues:
  - default
```


`[Ravioli] Could not load config file  /config/sidekiq.yml (Ravioli::BuildError)`
```
ruby/2.7.0/psych/class_loader.rb:99:in `find': Tried to load unspecified class: Symbol (Psych::DisallowedClass)
```