### PR TITLE
Remove limits on Rails versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     ravioli (0.2.6)
-      activesupport (>= 7.0, < 7.3)
+      activesupport (>= 7.0)
 
 GEM
   remote: https://rubygems.org/
@@ -290,7 +290,7 @@ DEPENDENCIES
   guard-rspec
   guard-rubocop
   pry
-  rails (>= 7.0, < 7.3)
+  rails (>= 7.0)
   ravioli!
   rspec (~> 3.9)
   rspec-rails

--- a/lib/ravioli/version.rb
+++ b/lib/ravioli/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ravioli
-  VERSION = "0.2.6"
+  VERSION = "0.2.7"
 end

--- a/ravioli.gemspec
+++ b/ravioli.gemspec
@@ -27,13 +27,13 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport", ">= 7.0", "< 7.3"
+  spec.add_dependency "activesupport", ">= 7.0"
 
   spec.add_development_dependency "guard"
   spec.add_development_dependency "guard-rspec"
   spec.add_development_dependency "guard-rubocop"
   spec.add_development_dependency "pry"
-  spec.add_development_dependency "rails", ">= 7.0", "< 7.3"
+  spec.add_development_dependency "rails", ">= 7.0"
   spec.add_development_dependency "rspec", "~> 3.9"
   spec.add_development_dependency "rspec-rails"
   spec.add_development_dependency "rubocop", ">= 1.0"


### PR DESCRIPTION
Who's to say Ravioli doesn't work on new, unreleased versions of Rails?! Remove the upper limit on Rails versions so users can test Ravioli on newer Rails versions.